### PR TITLE
Fixed Application.GetApplicationArgument(string[]);

### DIFF
--- a/src/Command.cs
+++ b/src/Command.cs
@@ -127,37 +127,7 @@ namespace OpenShell
 
 			for (int x = 0; x < this.Flags.Length; x++)
 				this.FlagHash.Add(this.Flags[x].FlagString, this.Flags[x]);		
-
-			Program.Debug.Log($"FlagHash.Count: {this.FlagHash.Count}");
 		}
-
-		/// <summary>
-		/// Generates an array of flag instances from the raw command string
-		/// </summary>
-		/// <returns> Flag instance array. </returns>
-		// Command.Flag[] GetFlags()
-		// {
-		// 	char FlagChar = '-'; 
-
-		// 	int occuranceTemp = 0;
-
-		// 	Stack<Flag> FlagStack = new Stack<Flag>();
-			 
-		// 	for (int x = 0; x < this.Parameters.Length; x++)
-		// 		if (Parameters[x][0] == FlagChar)
-		// 		{
-		// 			Program.Debug.Log($"Paramters[x]: {Parameters[x] = StringTools.OmitCharOccurances(this.Parameters[x][0], occuranceTemp, this.Parameters[x])}"); 
-
-		// 			if (x >= (Parameters.Length - 1))
-		// 				continue;
-
-		// 			FlagStack.Push(new Command.Flag(this.Parameters[x], this.Parameters[x + 1])); 
-
-		// 			x += 2;
-		// 		}
-
-		// 	return FlagStack.ToArray(); 
-		// }
 
 		public Command(string command)
 		{
@@ -183,13 +153,6 @@ namespace OpenShell
 				this.Flags  = new Command.Flag[] {};
 
 				this.HashFlags();
-
-				// Program.Debug.Log($"InputFlagSize: {this.InputFlags.Length}");
-
-				// for (int x = 0; x < this.InputFlags.Length; x++)
-				// 	Program.Debug.Log($"InputFlagName: {this.InputFlags[x].FlagString}");
-
-				// ArrayTools.PrintArray<string>(this.Parameters);
 			}
 		}
 	
@@ -212,8 +175,6 @@ namespace OpenShell
 
 				this.Parameters = ArrayTools.OmitElementAtIndex<string>(SplittedString, 0);
 				this.Aliases = null;
-	
-				// ArrayTools.PrintArray<string>(this.Parameters);
 			}
 			
 			this.Flags = defaultFlags;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -11,15 +11,13 @@ namespace OpenShell
 
 		static void Main(string[] args)
 		{
-			Application application = new Application(new AppConfiguration("Foo", new Command("foo", new Command.Flag[] { new Command.Flag("flag"), new Command.Flag("flag1") } )),
+			Application application = new Application(new AppConfiguration("Foo", new Command("foo", new Command.Flag[] { new Command.Flag("flag") { Value = "value" }, new Command.Flag("flag1") } )),
 													(ApplicationArgument applicationArgument) => {
-															Program.PrintApplicationArgument(applicationArgument);
 															return null;
 														}
 													), 
 													application1 = new Application(new AppConfiguration("Foo1", new Command("foo1", new Command.Flag[] { new Command.Flag("flag"), new Command.Flag("flag1") } )),
 													(ApplicationArgument applicationArgument) => {
-															// Program.PrintApplicationArgument(applicationArgument);
 															return null;
 														}
 													);
@@ -43,24 +41,5 @@ namespace OpenShell
 
 			return; 
 		}  
-
-		public static void PrintApplicationArgument(ApplicationArgument applicationArgument)
-		{
-			Console.WriteLine("Flags:");
-			for (int x = 0; x < applicationArgument.Flags.Length; x++)
-				Console.WriteLine($"{applicationArgument.Flags[x].FlagString}: {applicationArgument.Flags[x].Value}");
-
-			Console.WriteLine('\n');
-
-			Console.WriteLine("Single Flags:");
-			for (int x = 0; x < applicationArgument.SingleFlags.Length; x++)
-				Console.WriteLine($"{applicationArgument.SingleFlags[x].FlagString}");
-
-			Console.WriteLine('\n');
-
-			Console.WriteLine("Raw Values:");
-			for (int x = 0; x < applicationArgument.RawValues.Length; x++)
-				Console.WriteLine($"{applicationArgument.RawValues[x]}");
-		}	
 	}
 }

--- a/src/Shell.cs
+++ b/src/Shell.cs
@@ -226,11 +226,7 @@ namespace OpenShell
 								Application application = null;
 
 								if ((application = this.GetApplication(command)) != null)
-								{
-									Program.Debug.Log($"Application Hash Size: {application.Configuration.AppCommand.FlagHash.Count}");		
-									
 									return application.Run(command);
-								}
 		
 								throw new CommandNotFoundException(command);
 							}


### PR DESCRIPTION
Changes:
	1. Fixed the invalid construction of ApplicationArgument
	   instances by Application.GetApplicationArgument(string[]);

Bugs:
	Null!